### PR TITLE
MBS-5843: Fix unit tests for moodle 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10
+        image: postgres:12
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -31,6 +31,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - php: '8.0'
+            moodle-branch: 'MOODLE_400_STABLE'
+            database: 'mariadb'
+          - php: '8.0'
+            moodle-branch: 'MOODLE_400_STABLE'
+            database: 'pgsql'
+          - php: '7.4'
+            moodle-branch: 'MOODLE_400_STABLE'
+            database: 'mariadb'
+          - php: '7.4'
+            moodle-branch: 'MOODLE_400_STABLE'
+            database: 'pgsql'
           - php: '8.0'
             moodle-branch: 'MOODLE_311_STABLE'
             database: 'mariadb'

--- a/tests/helper.php
+++ b/tests/helper.php
@@ -79,6 +79,7 @@ class qtype_geogebra_test_helper extends question_test_helper {
      * @return \stdClass formdata
      */
     public function get_geogebra_question_form_data_point() {
+        global $CFG;
         $form = new stdClass();
         $form->name = "Finding a point in the plane";
         $form->questiontext = array();
@@ -101,6 +102,9 @@ class qtype_geogebra_test_helper extends question_test_helper {
         $form->noanswers = 1;
         $form->answer = array();
         $form->answer[0] = 'e';
+        if ($CFG->version >= 2022041900) {
+            $form->status = \core_question\local\bank\question_version_status::QUESTION_STATUS_READY;
+        }
 
         $form->fraction = array();
         $form->fraction[0] = '1.0';
@@ -131,6 +135,7 @@ class qtype_geogebra_test_helper extends question_test_helper {
      * @return \stdClass questiondata
      */
     public function get_geogebra_question_data_point() {
+        global $CFG;
         $q = new stdClass();
         $q->name = 'Finding a point in the plane';
         $q->questiontext = "Drag the point to ({a}/{b})";
@@ -141,9 +146,9 @@ class qtype_geogebra_test_helper extends question_test_helper {
         $q->penalty = 0.3333333;
         $q->qtype = 'geogebra';
         $q->length = '1';
-        $q->hidden = '0';
         $q->createdby = '2';
         $q->modifiedby = '2';
+        $q->idnumber = 0;
         $q->options = new stdClass();
         $q->options->answers = array();
         $q->options->answers[0] = new stdClass();
@@ -159,6 +164,9 @@ class qtype_geogebra_test_helper extends question_test_helper {
         $q->options->ggbcodebaseversion = '5.0';
         $q->options->israndomized = 1;
         $q->options->randomizedvar = 'a,b,';
+        if ($CFG->version >= 2022041900) {
+            $q->status = \core_question\local\bank\question_version_status::QUESTION_STATUS_READY;
+        }
 
         return $q;
     }

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -72,6 +72,7 @@ class questiontype_test extends advanced_testcase {
     protected function get_test_question_data() {
         $q = new stdClass;
         $q->id = 1;
+        $q->idnumber = 0;
         $q->options = new stdClass();
         $q->options->answers[13] = (object)array(
             'id'             => 13,
@@ -123,6 +124,8 @@ class questiontype_test extends advanced_testcase {
     }
 
     public function test_question_saving_point() {
+        global $CFG;
+
         $this->resetAfterTest(true);
         $this->setAdminUser();
 
@@ -143,7 +146,12 @@ class questiontype_test extends advanced_testcase {
         $fromform = $form->get_data();
 
         $returnedfromsave = $this->qtype->save_question($questiondata, $fromform);
-        $actualquestionsdata = question_load_questions(array($returnedfromsave->id));
+        // TODO: Field 'idnumber' has been moved from core to the plugin. Until the refactor, we just add it here in the test.
+        if ($CFG->version >= 2022041900) {
+            $actualquestionsdata = question_load_questions(array($returnedfromsave->id), 'qbe.idnumber');
+        } else {
+            $actualquestionsdata = question_load_questions(array($returnedfromsave->id));
+        }
         $actualquestiondata = end($actualquestionsdata);
 
         foreach ($questiondata as $property => $value) {


### PR DESCRIPTION
We have a new question API attribute `status` in moodle 4.0, so we need to adapt the unit tests a little bit. Implementing this new attribute `status` is still on the todo list for the the rework. Same goes for field `idnumber` which apparently has been moved to the plugins, so we have to somehow fake it in the tests.