### PR TITLE
MDL-71941 core_grades: use 'gradenoun' core string

### DIFF
--- a/edit_geogebra_form.php
+++ b/edit_geogebra_form.php
@@ -98,7 +98,7 @@ class qtype_geogebra_edit_form extends question_edit_form {
         $answeroptions[] = $mform->createElement('text', 'answer',
                 $label, array('size' => 40));
         $answeroptions[] = $mform->createElement('select', 'fraction',
-                get_string('grade', 'grades'), $gradeoptions);
+                get_string('gradenoun'), $gradeoptions);
         $repeated[0] = $mform->createElement('group', 'answeroptions',
                 $label, $answeroptions, null, false);
         $repeated[1] = $mform->createElement('hidden', 'feedback');

--- a/edit_geogebra_form.php
+++ b/edit_geogebra_form.php
@@ -92,13 +92,21 @@ class qtype_geogebra_edit_form extends question_edit_form {
      */
     protected function get_per_answer_fields($mform, $label, $gradeoptions,
             &$repeatedoptions, &$answersoption) {
+        global $CFG;
+        if ((int)$CFG->branch < 311) {
+            // Pre-3.11 string.
+            $gradestr = get_string('grade', 'grades');
+        } else {
+            // New string for "Grade", see MDL-71941.
+            $gradestr = get_string('gradenoun');
+        }
 
         $repeated = array();
         $answeroptions = array();
         $answeroptions[] = $mform->createElement('text', 'answer',
                 $label, array('size' => 40));
         $answeroptions[] = $mform->createElement('select', 'fraction',
-                get_string('gradenoun'), $gradeoptions);
+                $gradestr, $gradeoptions);
         $repeated[0] = $mform->createElement('group', 'answeroptions',
                 $label, $answeroptions, null, false);
         $repeated[1] = $mform->createElement('hidden', 'feedback');

--- a/question.php
+++ b/question.php
@@ -248,10 +248,10 @@ class qtype_geogebra_question extends question_graded_automatically {
                         $summary .= $answer->answer . '=';
                         if ($correct) {
                             $fraction += $answer->fraction;
-                            $summary .= 'true' . ', ' . get_string('grade', 'grades') . ': ' .
+                            $summary .= 'true' . ', ' . get_string('gradenoun') . ': ' .
                                     format_float($answer->fraction, 2, false, false);
                         } else {
-                            $summary .= 'false' . ', ' . get_string('grade', 'grades') . ': 0';
+                            $summary .= 'false' . ', ' . get_string('gradenoun') . ': 0';
                         }
                         $j++;
                     }

--- a/question.php
+++ b/question.php
@@ -229,9 +229,17 @@ class qtype_geogebra_question extends question_graded_automatically {
      * @return string a plain text summary of that response, that could be used in reports.
      */
     public function summarise_response(array $response) {
+        global $CFG;
         if (empty($this->answers) && !$this->isexercise) {
             return "Response graded manually";
         } else {
+            if ((int)$CFG->branch < 311) {
+                // Pre-3.11 string.
+                $gradestr = get_string('grade', 'grades');
+            } else {
+                // New string for "Grade", see MDL-71941.
+                $gradestr = get_string('gradenoun');
+            }
             $resp = $response['answer'];
             if ($resp === '' && !$this->isexercise) {
                 return get_string('noresponse', 'question');
@@ -248,10 +256,10 @@ class qtype_geogebra_question extends question_graded_automatically {
                         $summary .= $answer->answer . '=';
                         if ($correct) {
                             $fraction += $answer->fraction;
-                            $summary .= 'true' . ', ' . get_string('gradenoun') . ': ' .
+                            $summary .= 'true' . ', ' . $gradestr . ': ' .
                                     format_float($answer->fraction, 2, false, false);
                         } else {
-                            $summary .= 'false' . ', ' . get_string('gradenoun') . ': 0';
+                            $summary .= 'false' . ', ' . $gradestr . ': 0';
                         }
                         $j++;
                     }


### PR DESCRIPTION
Replace ('grade','grades') string by core ('gradenoun') string.

This will help unit tests to pass: question_test.php and walkthrough_test.php

See: https://tracker.moodle.org/browse/MDL-71941
See: https://github.com/moodle/moodle/commit/1e2300fbd6850fde15ad3f00430f527eb44c5570